### PR TITLE
商品詳細編集の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,13 +19,13 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def update
-  #   if item.update(item_params)
-  #     redirect_to root_path
-  #   else
-  #     rendar :edit
-  #   end
-  # end
+  def update
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      rendar :edit
+    end
+  end
 
   # def destroy
   #   if @item.destroy(item_params)

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -83,7 +83,7 @@ app/assets/stylesheets/items/new.css %>
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>


### PR DESCRIPTION
# what
商品詳細の編集機能の実装

# why
商品の詳細を正しく編集するため

編集の様子は下記のとおりです。
・投稿者だけが編集できて編集前は出品時の情報が入っている
https://gyazo.com/98ebc656ffc8cbb5727e441c868bfcbf